### PR TITLE
Add a link to ember-redux!

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Full Stack
 * CodeSandbox [Ember-CLI (vanilla)](https://codesandbox.io/s/github/mike-north/ember-new-output/tree/vanilla)
 * CodeSandbox [Ember-CLI w/ TypeScript](https://codesandbox.io/s/github/mike-north/ember-new-output/tree/ts)
+* CodeSandbox [Ember-CLI w/ Redux](https://codesandbox.io/s/github/NullVoxPopuli/codesandbox-ember-redux-template)
 * Glitch [Ember-CLI (vanilla)](https://glitch.com/edit/#!/ember-cli-start?path=app/templates/application.hbs)
 
 ## Frontend


### PR DESCRIPTION
#first :-p

This adds a link to a template demonstrating a common, contextual layout for redux in vanilla javascript